### PR TITLE
[iOS]첫 번째 화면 데이터 로드하여 뷰에 반영하도록 하였습니다.

### DIFF
--- a/iOS/DustNoticeApp/DustNoticeApp.xcodeproj/project.pbxproj
+++ b/iOS/DustNoticeApp/DustNoticeApp.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		5A64F6D32433591A00A1C8FF /* DustInfoDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A64F6D22433591A00A1C8FF /* DustInfoDelegate.swift */; };
 		5A64F6E02434E66A00A1C8FF /* DustInfoViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A64F6DF2434E66A00A1C8FF /* DustInfoViewModels.swift */; };
 		5A84EB7724359C23006E432F /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A84EB7624359C23006E432F /* LocationManager.swift */; };
+		5A84EB842435F463006E432F /* DustInfoDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A84EB832435F463006E432F /* DustInfoDecoder.swift */; };
+		5A84EB862435F499006E432F /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A84EB852435F499006E432F /* NetworkManager.swift */; };
+		5A84EB882435F8A4006E432F /* Station.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A84EB872435F8A4006E432F /* Station.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +77,9 @@
 		5A64F6DF2434E66A00A1C8FF /* DustInfoViewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DustInfoViewModels.swift; sourceTree = "<group>"; };
 		5A84EB7624359C23006E432F /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		5A84EB7D2435C376006E432F /* Janggi-dong.gpx */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "Janggi-dong.gpx"; sourceTree = "<group>"; };
+		5A84EB832435F463006E432F /* DustInfoDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DustInfoDecoder.swift; sourceTree = "<group>"; };
+		5A84EB852435F499006E432F /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
+		5A84EB872435F8A4006E432F /* Station.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Station.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -105,6 +111,7 @@
 			isa = PBXGroup;
 			children = (
 				5A0CBCC22432EC0D003B9774 /* DustInfo.swift */,
+				5A84EB872435F8A4006E432F /* Station.swift */,
 				5A0CBCCA2432FF6E003B9774 /* DustInfoDataSource.swift */,
 			);
 			path = Models;
@@ -153,6 +160,7 @@
 		5A4A9D352431CF7B00354ABC /* DustNoticeApp */ = {
 			isa = PBXGroup;
 			children = (
+				5A84EB822435F444006E432F /* Coder */,
 				5A84EB7524359C12006E432F /* Network */,
 				5A64F6C924332F4300A1C8FF /* Utils */,
 				5A0CBCC72432F17C003B9774 /* Views */,
@@ -209,9 +217,18 @@
 		5A84EB7524359C12006E432F /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				5A84EB852435F499006E432F /* NetworkManager.swift */,
 				5A84EB7624359C23006E432F /* LocationManager.swift */,
 			);
 			path = Network;
+			sourceTree = "<group>";
+		};
+		5A84EB822435F444006E432F /* Coder */ = {
+			isa = PBXGroup;
+			children = (
+				5A84EB832435F463006E432F /* DustInfoDecoder.swift */,
+			);
+			path = Coder;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -347,6 +364,7 @@
 			files = (
 				5A4A9D3D2431CF7B00354ABC /* MapViewController.swift in Sources */,
 				5A64F6CD24332FB200A1C8FF /* CAGradientLayerExtension.swift in Sources */,
+				5A84EB842435F463006E432F /* DustInfoDecoder.swift in Sources */,
 				5A84EB7724359C23006E432F /* LocationManager.swift in Sources */,
 				5A0CBCC32432EC0D003B9774 /* DustInfo.swift in Sources */,
 				5A64F6D32433591A00A1C8FF /* DustInfoDelegate.swift in Sources */,
@@ -354,6 +372,8 @@
 				5A64F6CF2433316D00A1C8FF /* StatusViewModel.swift in Sources */,
 				5A64F6C824332EDE00A1C8FF /* StatusView.swift in Sources */,
 				5A4A9D3B2431CF7B00354ABC /* StationViewController.swift in Sources */,
+				5A84EB882435F8A4006E432F /* Station.swift in Sources */,
+				5A84EB862435F499006E432F /* NetworkManager.swift in Sources */,
 				5A4A9D372431CF7B00354ABC /* AppDelegate.swift in Sources */,
 				5A0CBCC92432F1A1003B9774 /* DustInfoCell.swift in Sources */,
 				5A64F6E02434E66A00A1C8FF /* DustInfoViewModels.swift in Sources */,

--- a/iOS/DustNoticeApp/DustNoticeApp.xcodeproj/project.pbxproj
+++ b/iOS/DustNoticeApp/DustNoticeApp.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		5A64F6D22433591A00A1C8FF /* DustInfoDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DustInfoDelegate.swift; sourceTree = "<group>"; };
 		5A64F6DF2434E66A00A1C8FF /* DustInfoViewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DustInfoViewModels.swift; sourceTree = "<group>"; };
 		5A84EB7624359C23006E432F /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
+		5A84EB7D2435C376006E432F /* Janggi-dong.gpx */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "Janggi-dong.gpx"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -131,6 +132,7 @@
 		5A4A9D2A2431CF7B00354ABC = {
 			isa = PBXGroup;
 			children = (
+				5A84EB7D2435C376006E432F /* Janggi-dong.gpx */,
 				5A4A9D352431CF7B00354ABC /* DustNoticeApp */,
 				5A4A9D4E2431CF7D00354ABC /* DustNoticeAppTests */,
 				5A4A9D592431CF7D00354ABC /* DustNoticeAppUITests */,

--- a/iOS/DustNoticeApp/DustNoticeApp.xcodeproj/xcshareddata/xcschemes/DustNoticeApp.xcscheme
+++ b/iOS/DustNoticeApp/DustNoticeApp.xcodeproj/xcshareddata/xcschemes/DustNoticeApp.xcscheme
@@ -71,8 +71,8 @@
          </BuildableReference>
       </BuildableProductRunnable>
       <LocationScenarioReference
-         identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
-         referenceType = "1">
+         identifier = "../../Janggi-dong.gpx"
+         referenceType = "0">
       </LocationScenarioReference>
    </LaunchAction>
    <ProfileAction

--- a/iOS/DustNoticeApp/DustNoticeApp/Coder/DustInfoDecoder.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/Coder/DustInfoDecoder.swift
@@ -8,8 +8,6 @@
 
 import Foundation
 
-
-
 struct DustInfoDecoder {
     static func decode(from string: String, with manager: NetworkManager, completionHandler: @escaping (Station?) -> ()) {
         manager.getResource(from: string) { (data, error) in

--- a/iOS/DustNoticeApp/DustNoticeApp/Coder/DustInfoDecoder.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/Coder/DustInfoDecoder.swift
@@ -11,8 +11,8 @@ import Foundation
 
 
 struct DustInfoDecoder {
-    static func decode(from: String, with manager: NetworkManager, completionHandler: @escaping (Station?) -> ()) {
-        manager.getResource(from: from) { (data, error) in
+    static func decode(from string: String, with manager: NetworkManager, completionHandler: @escaping (Station?) -> ()) {
+        manager.getResource(from: string) { (data, error) in
             guard error == nil else { return }
             guard let data = data else { return }
             guard let station = try? JSONDecoder().decode(Station.self, from: data) else { return }

--- a/iOS/DustNoticeApp/DustNoticeApp/Coder/DustInfoDecoder.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/Coder/DustInfoDecoder.swift
@@ -1,0 +1,29 @@
+//
+//  DustInfoDecoder.swift
+//  DustNoticeApp
+//
+//  Created by kimdo2297 on 2020/04/02.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import Foundation
+
+
+
+struct DustInfoDecoder {
+    static func decode(from: String, with manager: NetworkManager, completionHandler: @escaping (Station?) -> ()) {
+        manager.getResource(from: from) { (data, error) in
+            guard error == nil else { return }
+            guard let data = data else { return }
+            guard let prettyPrintedString = NSString(data: data, encoding: String.Encoding.utf8.rawValue) else { return }
+            print(prettyPrintedString)
+            do {
+               let station = try JSONDecoder().decode(Station.self, from: data)
+//                completionHandler(station)
+                print(station)
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
+}

--- a/iOS/DustNoticeApp/DustNoticeApp/Coder/DustInfoDecoder.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/Coder/DustInfoDecoder.swift
@@ -15,15 +15,8 @@ struct DustInfoDecoder {
         manager.getResource(from: from) { (data, error) in
             guard error == nil else { return }
             guard let data = data else { return }
-            guard let prettyPrintedString = NSString(data: data, encoding: String.Encoding.utf8.rawValue) else { return }
-            print(prettyPrintedString)
-            do {
-               let station = try JSONDecoder().decode(Station.self, from: data)
-//                completionHandler(station)
-                print(station)
-            } catch {
-                print(error.localizedDescription)
-            }
+            guard let station = try? JSONDecoder().decode(Station.self, from: data) else { return }
+            completionHandler(station)
         }
     }
 }

--- a/iOS/DustNoticeApp/DustNoticeApp/Delegates/DustInfoDelegate.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/Delegates/DustInfoDelegate.swift
@@ -30,4 +30,11 @@ final class DustInfoDelegate: NSObject, UITableViewDelegate {
         
         dustInfoDataSource.dustInfoViewModels.bind(at: firstRow, statusView: statusView)
     }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt: IndexPath) {
+        guard let statusView = statusView else { return }
+        guard let dustInfoDataSource = tableView.dataSource as? DustInfoDataSource else { return }
+        
+        dustInfoDataSource.dustInfoViewModels.bind(at: didSelectRowAt.row, statusView: statusView)
+    }
 }

--- a/iOS/DustNoticeApp/DustNoticeApp/Models/DustInfo.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/Models/DustInfo.swift
@@ -9,13 +9,13 @@
 import Foundation
 
 struct DustInfo: Codable {
-    let dustValue: UInt
-    let dustGrade: UInt
-    let measureDate: Date
+    var dataTime: String
+    var pm10Grade1h: String
+    var pm10Value: String
     
-    enum codingkeys: String, CodingKey {
-        case dustValue = "pm10Value"
-        case dustGrade = "pm10Grade"
-        case measureDate = "dataTime"
+    enum CodingKeys: String, CodingKey {
+        case dataTime = "dataTime"
+        case pm10Grade1h = "pm10Grade1h"
+        case pm10Value = "pm10Value"
     }
 }

--- a/iOS/DustNoticeApp/DustNoticeApp/Models/DustInfoDataSource.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/Models/DustInfoDataSource.swift
@@ -8,66 +8,17 @@
 
 import UIKit
 
-enum DummyData {
-    enum DummyDust {
-        static let good = DustInfo(dataTime: "10", pm10Grade1h: "1", pm10Value: "0")
-        static let usual = DustInfo(dataTime: "50", pm10Grade1h: "2", pm10Value: "0")
-        static let bad = DustInfo(dataTime: "120", pm10Grade1h: "3", pm10Value: "0")
-        static let veryBad = DustInfo(dataTime: "200", pm10Grade1h: "4", pm10Value: "0")
-    }
-    
-    enum DummyDustViewModels {
-        static let goods: [DustInfoViewModel] = {
-            var viewModels = [DustInfoViewModel]()
-            for _ in 0 ..< DustInfoDataSource.Quantity.numberOfRows / 4 {
-                viewModels.append(DustInfoViewModel(dustInfo: DummyDust.good))
-            }
-            return viewModels
-        }()
-        static let usuals: [DustInfoViewModel] = {
-            var viewModels = [DustInfoViewModel]()
-            for _ in 0 ..< DustInfoDataSource.Quantity.numberOfRows / 4 {
-                viewModels.append(DustInfoViewModel(dustInfo: DummyDust.usual))
-            }
-            return viewModels
-        }()
-        static let bads: [DustInfoViewModel] = {
-            var viewModels = [DustInfoViewModel]()
-            for _ in 0 ..< DustInfoDataSource.Quantity.numberOfRows / 4 {
-                viewModels.append(DustInfoViewModel(dustInfo: DummyDust.bad))
-            }
-            return viewModels
-        }()
-        static let veryBads: [DustInfoViewModel] = {
-            var viewModels = [DustInfoViewModel]()
-            for _ in 0 ..< DustInfoDataSource.Quantity.numberOfRows / 4 {
-                viewModels.append(DustInfoViewModel(dustInfo: DummyDust.veryBad))
-            }
-            return viewModels
-        }()
-        
-        static let max: [DustInfoViewModel] = {
-            var viewModels = [DustInfoViewModel]()
-            viewModels.append(contentsOf: goods)
-            viewModels.append(contentsOf: usuals)
-            viewModels.append(contentsOf: bads)
-            viewModels.append(contentsOf: veryBads)
-            return viewModels
-        }()
-    }
-}
-
 final class DustInfoDataSource: NSObject, UITableViewDataSource {
-    let dustInfoViewModels = DustInfoViewModels(dustInfoViewModels: DummyData.DummyDustViewModels.max)
+    let dustInfoViewModels: DustInfoViewModels
+    
+    init(dustInfoViewModels: DustInfoViewModels) {
+        self.dustInfoViewModels = dustInfoViewModels
+    }
 }
 
 extension DustInfoDataSource {
-    enum Quantity {
-        static let numberOfRows = 100
-    }
-    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return Quantity.numberOfRows
+        return dustInfoViewModels.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/iOS/DustNoticeApp/DustNoticeApp/Models/DustInfoDataSource.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/Models/DustInfoDataSource.swift
@@ -10,10 +10,10 @@ import UIKit
 
 enum DummyData {
     enum DummyDust {
-        static let good = DustInfo(dustValue: 10, dustGrade: 1, measureDate: Date())
-        static let usual = DustInfo(dustValue: 50, dustGrade: 2, measureDate: Date())
-        static let bad = DustInfo(dustValue: 120, dustGrade: 3, measureDate: Date())
-        static let veryBad = DustInfo(dustValue: 200, dustGrade: 4, measureDate: Date())
+        static let good = DustInfo(dataTime: "10", pm10Grade1h: "1", pm10Value: "0")
+        static let usual = DustInfo(dataTime: "50", pm10Grade1h: "2", pm10Value: "0")
+        static let bad = DustInfo(dataTime: "120", pm10Grade1h: "3", pm10Value: "0")
+        static let veryBad = DustInfo(dataTime: "200", pm10Grade1h: "4", pm10Value: "0")
     }
     
     enum DummyDustViewModels {

--- a/iOS/DustNoticeApp/DustNoticeApp/Models/Station.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/Models/Station.swift
@@ -1,0 +1,19 @@
+//
+//  Station.swift
+//  DustNoticeApp
+//
+//  Created by kimdo2297 on 2020/04/02.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import Foundation
+
+struct Station: Codable {
+    let stationName: String
+    var list: [DustInfo]
+    
+    enum codingkeys: String, CodingKey {
+         case stationName
+         case list = "list"
+     }
+}

--- a/iOS/DustNoticeApp/DustNoticeApp/Network/LocationManager.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/Network/LocationManager.swift
@@ -10,8 +10,11 @@ import Foundation
 import CoreLocation
 
 final class LocationManager: NSObject {
-    private let locationManager = CLLocationManager()
+    enum Notification {
+        static let subLocalityDidChange = Foundation.Notification.Name("subLocalityDidChange")
+    }
     private(set) var subLocality: String?
+    private let locationManager = CLLocationManager()
     
     override init() {
         super.init()
@@ -51,7 +54,9 @@ extension LocationManager: CLLocationManagerDelegate {
         guard let last = locations.last else { return }
         lookUpCurrentLocation(lastLocation: last) { placeMark in
             guard let placeMark = placeMark else { return }
-            self.subLocality = placeMark.subLocality
+            guard self.subLocality == nil else { return }
+            self.subLocality = placeMark.subLocality?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+            NotificationCenter.default.post(name: Notification.subLocalityDidChange, object: self)
         }
     }
 }

--- a/iOS/DustNoticeApp/DustNoticeApp/Network/NetworkManager.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/Network/NetworkManager.swift
@@ -1,0 +1,22 @@
+//
+//  NetworkManager.swift
+//  DustNoticeApp
+//
+//  Created by kimdo2297 on 2020/04/02.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import Foundation
+
+struct NetworkManager {
+    enum EndPoints {
+        static let dustURL = "http://52.7.82.194:8080/api/dust/"
+    }
+    
+    func getResource(from: String, resultHandler: @escaping (Data?, Error?)->()) {
+        guard let url = URL(string: from) else { return }
+        URLSession.shared.dataTask(with: url) { (data, response, error) in
+            resultHandler(data, error)
+        }.resume()
+    }
+}

--- a/iOS/DustNoticeApp/DustNoticeApp/Network/NetworkManager.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/Network/NetworkManager.swift
@@ -13,8 +13,8 @@ struct NetworkManager {
         static let dustURL = "http://52.7.82.194:8080/api/dust/"
     }
     
-    func getResource(from: String, resultHandler: @escaping (Data?, Error?)->()) {
-        guard let url = URL(string: from) else { return }
+    func getResource(from string: String, resultHandler: @escaping (Data?, Error?)->()) {
+        guard let url = URL(string: string) else { return }
         URLSession.shared.dataTask(with: url) { (data, response, error) in
             resultHandler(data, error)
         }.resume()

--- a/iOS/DustNoticeApp/DustNoticeApp/StationViewController.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/StationViewController.swift
@@ -26,13 +26,18 @@ final class StationViewController: UIViewController {
     
     private func configureObserver() {
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(foo),
+                                               selector: #selector(configureDustInfo),
                                                name: LocationManager.Notification.subLocalityDidChange,
                                                object: locationManager)
     }
     
-    @objc private func foo() {
-        
+    @objc private func configureDustInfo() {
+        guard let subLocality = locationManager.subLocality else { return }
+        DustInfoDecoder.decode(from: "\(NetworkManager.EndPoints.dustURL)\(subLocality)",
+        with: NetworkManager()) { station in
+            guard let station = station else { return }
+            
+        }
     }
     
     private func configureDustInfoDelegate() {

--- a/iOS/DustNoticeApp/DustNoticeApp/StationViewController.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/StationViewController.swift
@@ -36,8 +36,14 @@ final class StationViewController: UIViewController {
         DustInfoDecoder.decode(from: "\(NetworkManager.EndPoints.dustURL)\(subLocality)",
         with: NetworkManager()) { station in
             guard let station = station else { return }
-            
+            DispatchQueue.main.async {
+                self.configureStatusView(station.stationName)
+            }
         }
+    }
+    
+    private func configureStatusView(_ stationName: String) {
+        statusView.stationLabel.text = "\(stationName) 측정소 기준"
     }
     
     private func configureDustInfoDelegate() {

--- a/iOS/DustNoticeApp/DustNoticeApp/StationViewController.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/StationViewController.swift
@@ -14,7 +14,7 @@ final class StationViewController: UIViewController {
     @IBOutlet weak var statusView: StatusView!
     
     //MARK:- Internal Property
-    private let dustInfoDataSource = DustInfoDataSource()
+    private var dustInfoDataSource: DustInfoDataSource!
     private let dustInfoDelegate = DustInfoDelegate()
     private let locationManager = LocationManager()
     override func viewDidLoad() {
@@ -38,6 +38,8 @@ final class StationViewController: UIViewController {
             guard let station = station else { return }
             DispatchQueue.main.async {
                 self.configureStatusView(station.stationName)
+                self.configureDataSource(dustInfos: station.list)
+                self.dustInfoTableView.reloadData()
             }
         }
     }
@@ -46,12 +48,17 @@ final class StationViewController: UIViewController {
         statusView.stationLabel.text = "\(stationName) 측정소 기준"
     }
     
+    private func configureDataSource(dustInfos: [DustInfo]) {
+        let dustInfoViewModels = dustInfos.map{ DustInfoViewModel(dustInfo: $0) }
+        dustInfoDataSource = DustInfoDataSource(dustInfoViewModels: DustInfoViewModels(dustInfoViewModels))
+        dustInfoTableView.dataSource = dustInfoDataSource
+    }
+    
     private func configureDustInfoDelegate() {
         dustInfoDelegate.statusView = statusView
     }
     
     private func configureDustInfoTableView() {
-        dustInfoTableView.dataSource = dustInfoDataSource
         dustInfoTableView.delegate = dustInfoDelegate
         dustInfoTableView.register(DustInfoCell.self,
                                    forCellReuseIdentifier: DustInfoCell.reuseIdentifier)

--- a/iOS/DustNoticeApp/DustNoticeApp/StationViewController.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/StationViewController.swift
@@ -19,8 +19,20 @@ final class StationViewController: UIViewController {
     private let locationManager = LocationManager()
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureObserver()
         configureDustInfoDelegate()
         configureDustInfoTableView()
+    }
+    
+    private func configureObserver() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(foo),
+                                               name: LocationManager.Notification.subLocalityDidChange,
+                                               object: locationManager)
+    }
+    
+    @objc private func foo() {
+        
     }
     
     private func configureDustInfoDelegate() {

--- a/iOS/DustNoticeApp/DustNoticeApp/ViewModels/DustInfoViewModel.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/ViewModels/DustInfoViewModel.swift
@@ -27,8 +27,8 @@ final class DustInfoViewModel {
     }
     
     func bind(statusView: StatusView) {
-        statusView.measureLabel.text = String("\(dustValue) 𝜇g/m3")
-        statusView.dateLabel.text = measureDateString
+        statusView.measureLabel.text = String("\(dustGrade) 𝜇g/m3")
+//        statusView.dateLabel.text = measureDateString
         StatusViewModel.bind(statusView, dustGrade: dustGrade)
     }
     
@@ -41,13 +41,13 @@ final class DustInfoViewModel {
             return 1
         }
     }
-    
+
     private var dustValue: UInt {
-        return dustInfo.dustValue
+        return UInt(dustInfo.pm10Value) ?? 1
     }
     
     private var dustValueString: String {
-        return String(dustValue)
+        return dustInfo.pm10Value
     }
     
     enum DustGrade: UInt {
@@ -58,7 +58,7 @@ final class DustInfoViewModel {
     }
     
     private var dustGrade: DustGrade {
-        return DustGrade(rawValue: dustInfo.dustGrade) ?? DustGrade.good
+        return DustGrade(rawValue: UInt(dustInfo.pm10Grade1h) ?? 1) ?? DustGrade.good
     }
     
     private var backgroundColor: UIColor {
@@ -88,14 +88,14 @@ final class DustInfoViewModel {
         }
     }
     
-    private var measureDateString: String? {
-        let today = calendar.dateComponents([.day], from: Date())
-        let components = calendar.dateComponents([.day,.hour,.minute], from: dustInfo.measureDate)
-        guard let dayOfToday = today.day else { return nil }
-        guard let measureDay = components.day,
-            let measureHour = components.hour,
-            let measuerMinute = components.minute else { return nil }
-        guard let dayDifference = DayDifference(rawValue: dayOfToday - measureDay) else { return nil }
-        return "\(dayDifference.description) \(measureHour):\(measuerMinute)"
-    }
+//    private var measureDateString: String? {
+//        let today = calendar.dateComponents([.day], from: Date())
+//        let components = calendar.dateComponents([.day,.hour,.minute], from: dustInfo.measureDate)
+//        guard let dayOfToday = today.day else { return nil }
+//        guard let measureDay = components.day,
+//            let measureHour = components.hour,
+//            let measuerMinute = components.minute else { return nil }
+//        guard let dayDifference = DayDifference(rawValue: dayOfToday - measureDay) else { return nil }
+//        return "\(dayDifference.description) \(measureHour):\(measuerMinute)"
+//    }
 }

--- a/iOS/DustNoticeApp/DustNoticeApp/ViewModels/DustInfoViewModel.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/ViewModels/DustInfoViewModel.swift
@@ -28,7 +28,7 @@ final class DustInfoViewModel {
     
     func bind(statusView: StatusView) {
         statusView.measureLabel.text = String("\(dustValueString) 𝜇g/m3")
-//        statusView.dateLabel.text = measureDateString
+        statusView.dateLabel.text = measureDateString
         StatusViewModel.bind(statusView, dustGrade: dustGrade)
     }
     
@@ -87,15 +87,32 @@ final class DustInfoViewModel {
             }
         }
     }
+    private var measureDateString: String? {
+        let today = calendar.dateComponents([.day], from: Date())
+        guard let dayOfToday = today.day else { return nil }
+        
+        guard let date = date(from: dustInfo.dataTime) else { return nil }
+        let components = calendar.dateComponents([.day,.hour,.minute], from: date)
+        guard let measureDay = components.day,
+            let measureHour = components.hour,
+            let measuerMinute = components.minute else { return nil }
+        
+        guard let dayDifference = DayDifference(rawValue: dayOfToday - measureDay) else { return nil }
+        return "\(dayDifference.description) \(measureHour):\(String(format: "%02d", measuerMinute))"
+    }
     
-//    private var measureDateString: String? {
-//        let today = calendar.dateComponents([.day], from: Date())
-//        let components = calendar.dateComponents([.day,.hour,.minute], from: dustInfo.measureDate)
-//        guard let dayOfToday = today.day else { return nil }
-//        guard let measureDay = components.day,
-//            let measureHour = components.hour,
-//            let measuerMinute = components.minute else { return nil }
-//        guard let dayDifference = DayDifference(rawValue: dayOfToday - measureDay) else { return nil }
-//        return "\(dayDifference.description) \(measureHour):\(measuerMinute)"
-//    }
+    private func date(from string: String) -> Date? {
+        guard let date = DateFormatter.dustDateFormatter.date(from: string) else { return nil }
+        return date
+    }
+}
+
+
+extension DateFormatter {
+    static let dustDateFormatter : DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm"
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+        return dateFormatter
+    }()
 }

--- a/iOS/DustNoticeApp/DustNoticeApp/ViewModels/DustInfoViewModel.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/ViewModels/DustInfoViewModel.swift
@@ -27,13 +27,13 @@ final class DustInfoViewModel {
     }
     
     func bind(statusView: StatusView) {
-        statusView.measureLabel.text = String("\(dustGrade) 𝜇g/m3")
+        statusView.measureLabel.text = String("\(dustValueString) 𝜇g/m3")
 //        statusView.dateLabel.text = measureDateString
         StatusViewModel.bind(statusView, dustGrade: dustGrade)
     }
     
     private func multiplier() -> CGFloat {
-        let dustValue = Double(self.dustValue)
+        let dustValue = Double(self.dustValueUInt)
         let maxPollutionValue = 200.0
         if dustValue < maxPollutionValue {
             return CGFloat(dustValue / maxPollutionValue)
@@ -42,7 +42,7 @@ final class DustInfoViewModel {
         }
     }
 
-    private var dustValue: UInt {
+    private var dustValueUInt: UInt {
         return UInt(dustInfo.pm10Value) ?? 1
     }
     

--- a/iOS/DustNoticeApp/DustNoticeApp/ViewModels/DustInfoViewModels.swift
+++ b/iOS/DustNoticeApp/DustNoticeApp/ViewModels/DustInfoViewModels.swift
@@ -11,7 +11,7 @@ import Foundation
 final class DustInfoViewModels {
     private let dustInfoViewModels: [DustInfoViewModel]
     
-    init(dustInfoViewModels: [DustInfoViewModel]) {
+    init(_ dustInfoViewModels: [DustInfoViewModel]) {
         self.dustInfoViewModels = dustInfoViewModels
     }
     

--- a/iOS/DustNoticeApp/Janggi-dong.gpx
+++ b/iOS/DustNoticeApp/Janggi-dong.gpx
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<gpx version="1.1" creator="Xcode">
+    
+    <!--
+     Provide one or more waypoints containing a latitude/longitude pair. If you provide one
+     waypoint, Xcode will simulate that specific location. If you provide multiple waypoints,
+     Xcode will simulate a route visiting each waypoint.
+     -->
+    <wpt lat="37.647753" lon="126.680631">
+        <name>Cupertino</name>
+        
+        <!--
+         Optionally provide a time element for each waypoint. Xcode will interpolate movement
+         at a rate of speed based on the time elapsed between each waypoint. If you do not provide
+         a time element, then Xcode will use a fixed rate of speed.
+         
+         Waypoints must be sorted by time in ascending order.
+         -->
+        <time>2014-09-24T14:55:37Z</time>
+    </wpt>
+    
+</gpx>


### PR DESCRIPTION
이슈 #27 을 해결하였습니다.

> 새롭게 도입한 것
* 테이블 행의 개수가 24개뿐이라 끝까지 스크롤이 안되서 행을 선택했을 때도 상단 뷰(Status View)가 업데이트 되도록 
> 깨달은 점 
* JK 말대로 API 가 아직 사용안할 때는 Mock, Stub 으로 최대한 흡사하게 데이터를 로드하는 코드를 작성했어야 했다는 걸 깨달았습니다. 
서버로부터 데이터의 로드할 때 이전의 Codable 객체의 타입이 다른 것부터 삐걱거리더니 많은 걸 바꿔줬어야 했습니다.. 
다음부턴 주의하겠습니다. ( 시뮬레이터 GPS 부터 오늘 시행착오를 많이 겪었습니다 ㅋㅋ )